### PR TITLE
Handle CLRF whitespace of .ic files

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -412,7 +412,7 @@ fn parse_name(code: &Str) -> (&Str, &Str) {
 
 fn skip_whitespace(code: &Str) -> &Str {
   let mut i: usize = 0;
-  while i < code.len() && (code[i] == b' ' || code[i] == b'\n') {
+  while i < code.len() && code[i].is_ascii_whitespace() {
     i += 1;
   }
   &code[i..]


### PR DESCRIPTION
On windows you get what seems to be a parsing error:

This fixes it.

Same idea as: https://github.com/HigherOrderCO/hvm-core/pull/15